### PR TITLE
Fix typos

### DIFF
--- a/core-concepts.md
+++ b/core-concepts.md
@@ -77,7 +77,7 @@ namespace App\Models;
 
 use App\Contracts\Models\Addon as Contract;
 use Cone\Bazar\Concerns\InteractsWithProxy;
-use Illuminate\Databse\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;
 
 class Addon extends Model implements Contract
 {

--- a/fields.md
+++ b/fields.md
@@ -56,7 +56,7 @@ It may happen that the attribute does not exists on the model that matches with 
 
 ```php
 use Cone\Root\Fields\Text;
-use Illuminate\Databsase\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 
 Text::make('Title')
@@ -73,7 +73,7 @@ You may define custom value formatters for the field values. In that case you ca
 
 ```php
 use Cone\Root\Fields\Number;
-use Illuminate\Databsase\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Number;
 
@@ -92,7 +92,7 @@ namespace App\Root\Fields;
 
 use Cone\Root\Fields\Field;
 use Illuminate\Http\Request;
-use Illuminate\Databsase\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;
 
 class CustomField extends Field
 {

--- a/fields.md
+++ b/fields.md
@@ -85,7 +85,7 @@ Number::make('Price')
 
 ### Value Hydration
 
-You may define custom value hydration logic on your field clasas. To do so, you can easily override the default `hydrate` method:
+You may define custom value hydration logic on your field class. To do so, you can easily override the default `hydrate` method:
 
 ```php
 namespace App\Root\Fields;
@@ -256,7 +256,7 @@ $field->cols(100);
 
 ### Relation Fields
 
-Relation fields are represanting Eloquent relation definitions on the resource models. Relation fields are highly customizable and provide a nice and detailed API.
+Relation fields are representing Eloquent relation definitions on the resource models. Relation fields are highly customizable and provide a nice and detailed API.
 
 #### BelongsTo
 


### PR DESCRIPTION
```bash
cat $(git ls-files -- '*.md')|hunspell -d dictionaries/en/en_US -l|sed -e 's#\([a-z]\)\([A-Z]\)#\1 \2#g'|hunspell -d dictionaries/en/en_US -l|sort|uniq -i
```

1. get all Markdown contents
2. print misspelled words
3. replace "camelCase" with "camel Case"
4. run hunspell again to filter out known words